### PR TITLE
Improved solver API

### DIFF
--- a/include/bill/sat/solver.hpp
+++ b/include/bill/sat/solver.hpp
@@ -137,6 +137,13 @@ public:
 #pragma endregion
 
 #pragma region Modifiers
+	void restart()
+	{
+		solver_.reset();
+		solver_ = std::make_unique<solver_type>();
+		state_ = result::states::undefined;
+	}
+
 	var_type add_variable()
 	{
 		return solver_->newVar();
@@ -275,6 +282,13 @@ public:
 #pragma endregion
 
 #pragma region Modifiers
+	void restart()
+	{
+		solver_.reset();
+		solver_ = std::make_unique<solver_type>();
+		state_ = result::states::undefined;
+	}
+
 	var_type add_variable()
 	{
 		return solver_->newVar();
@@ -413,6 +427,13 @@ public:
 #pragma endregion
 
 #pragma region Modifiers
+	void restart()
+	{
+		solver_.reset();
+		solver_ = std::make_unique<solver_type>();
+		state_ = result::states::undefined;
+	}
+
 	var_type add_variable()
 	{
 		return solver_->newVar();

--- a/include/bill/sat/solver.hpp
+++ b/include/bill/sat/solver.hpp
@@ -78,6 +78,7 @@ public:
 		}
 	}
 
+#pragma region Constructors
 	result(states state = states::undefined)
 	    : state_(state)
 	{}
@@ -91,6 +92,7 @@ public:
 	    : state_(states::unsatisfiable)
 	    , data_(unsat_core)
 	{}
+#pragma endregion
 
 #pragma region Properties
 	inline bool is_satisfiable() const

--- a/include/bill/sat/solver.hpp
+++ b/include/bill/sat/solver.hpp
@@ -26,18 +26,6 @@
 #include "sat_solvers/glucose.hpp"
 #include "sat_solvers/maple.hpp"
 #pragma GCC diagnostic pop
-#else
-#pragma warning(push)
-#pragma warning(disable : 4571)
-#pragma warning(disable : 4625)
-#pragma warning(disable : 4626)
-#pragma warning(disable : 4710)
-#pragma warning(disable : 4774)
-#pragma warning(disable : 4820)
-#include "sat_solvers/ghack.hpp"
-#include "sat_solvers/glucose.hpp"
-#include "sat_solvers/maple.hpp"
-#pragma warning(pop)
 #endif
 
 #include "types.hpp"

--- a/include/bill/sat/solver.hpp
+++ b/include/bill/sat/solver.hpp
@@ -61,6 +61,23 @@ public:
 		dirty,
 	};
 
+	static std::string to_string(states const& state)
+	{
+		switch (state) {
+		case states::satisfiable:
+			return "satisfiable";
+		case states::unsatisfiable:
+			return "unsatisfiable";
+		case states::timeout:
+			return "timeout";
+		case states::dirty:
+			return "dirty";
+		case states::undefined:
+		default:
+			return "undefined";
+		}
+	}
+
 	result(states state = states::undefined)
 	    : state_(state)
 	{}
@@ -101,6 +118,11 @@ public:
 	inline operator bool() const
 	{
 		return (state_ == states::satisfiable);
+	}
+
+	inline explicit operator std::string() const
+	{
+		return result::to_string(state_);
 	}
 #pragma endregion
 

--- a/include/bill/sat/solver.hpp
+++ b/include/bill/sat/solver.hpp
@@ -26,6 +26,18 @@
 #include "sat_solvers/glucose.hpp"
 #include "sat_solvers/maple.hpp"
 #pragma GCC diagnostic pop
+#else
+#pragma warning(push)
+#pragma warning(disable : 4571)
+#pragma warning(disable : 4625)
+#pragma warning(disable : 4626)
+#pragma warning(disable : 4710)
+#pragma warning(disable : 4774)
+#pragma warning(disable : 4820)
+#include "sat_solvers/ghack.hpp"
+#include "sat_solvers/glucose.hpp"
+#include "sat_solvers/maple.hpp"
+#pragma warning(pop)
 #endif
 
 #include "types.hpp"
@@ -118,6 +130,10 @@ public:
 	solver()
 	    : solver_(std::make_unique<solver_type>())
 	{}
+
+	/* disallow copying */
+	solver(solver<solvers::glucose_41> const&) = delete;
+	solver<solvers::glucose_41>& operator=(const solver<solvers::glucose_41>&) = delete;
 #pragma endregion
 
 #pragma region Modifiers
@@ -252,6 +268,10 @@ public:
 	solver()
 	    : solver_(std::make_unique<solver_type>())
 	{}
+
+	/* disallow copying */
+	solver(solver<solvers::ghack> const&) = delete;
+	solver<solvers::ghack>& operator=(const solver<solvers::ghack>&) = delete;
 #pragma endregion
 
 #pragma region Modifiers
@@ -386,6 +406,10 @@ public:
 	solver()
 	    : solver_(std::make_unique<solver_type>())
 	{}
+
+	/* disallow copying */
+	solver(solver<solvers::maple> const&) = delete;
+	solver<solvers::maple>& operator=(const solver<solvers::maple>&) = delete;
 #pragma endregion
 
 #pragma region Modifiers

--- a/tests/sat/sat.cpp
+++ b/tests/sat/sat.cpp
@@ -130,3 +130,25 @@ TEMPLATE_TEST_CASE("Model", "[sat][template]", SOLVER_TYPES)
 	                            | model.at(b.variable()) == lbool_type::true_;
 	CHECK(a_or_b_is_true);
 }
+
+TEMPLATE_TEST_CASE("Restart", "[sat][template]", SOLVER_TYPES)
+{
+	TestType solver;
+	auto const a = lit_type(solver.add_variable(), lit_type::polarities::positive);
+	auto const b = lit_type(solver.add_variable(), lit_type::polarities::positive);
+
+	auto const t0 = add_tseytin_and(solver, a, b);
+	auto const t1 = ~add_tseytin_or(solver, ~a, ~b);
+	auto const t2 = add_tseytin_xor(solver, t0, t1);
+	solver.add_clause(t2);
+
+	CHECK(solver.solve() == result::states::unsatisfiable);
+	CHECK(solver.num_variables() == 5u);
+	CHECK(solver.num_clauses() == 8u);
+
+	solver.restart();
+	CHECK(solver.solve() != result::states::unsatisfiable);
+	CHECK(solver.num_variables() == 0u);
+	CHECK(solver.num_clauses() == 0u);
+}
+


### PR DESCRIPTION
- Method to restart solvers (`restart`)
- Convert solver state to `std::string` (`to_string`)
- Disallow copying a solver