### PR TITLE
Enable Z3 as optional interface through CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,23 +24,32 @@ option(BILL_DOCS "Build documentation" OFF)
 option(BILL_EXAMPLES "Build examples" ON)
 option(BILL_EXPERIMENTS "Build experiments" OFF)
 option(BILL_TESTS "Build tests" OFF)
+option(BILL_Z3 "Enable Z3 interface" OFF)
 
 # Libs
 # =============================================================================
 add_subdirectory(lib)
 
-# Z3
-# =============================================================================
-add_library(z3int INTERFACE)
-target_include_directories(z3int SYSTEM INTERFACE /usr/local/include)
-target_link_directories(z3int INTERFACE /usr/local/lib)
-target_link_libraries(z3int INTERFACE z3)
-
 # Library
 # =============================================================================
 add_library(bill INTERFACE)
 target_include_directories(bill INTERFACE ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(bill INTERFACE fmt z3int)
+target_link_libraries(bill INTERFACE fmt)
+
+# Z3 (optional)
+# =============================================================================
+if(BILL_Z3)
+  target_compile_definitions(bill INTERFACE BILL_HAS_Z3)
+  set(BILL_Z3_INCLUDE_PATH "" CACHE PATH "Path to Z3 includes, e.g., z3++.h")
+  set(BILL_Z3_LIBRARY_PATH "" CACHE PATH "Path to Z3 library, e.g., libz3.a")
+  if(NOT ${BILL_Z3_INCLUDE_PATH} STREQUAL "")
+    target_include_directories(bill INTERFACE ${BILL_Z3_INCLUDE_PATH})
+  endif()
+  if(NOT ${BILL_Z3_LIBRARY_PATH} STREQUAL "")
+    target_link_directories(bill INTERFACE ${BILL_Z3_LIBRARY_PATH})
+  endif()
+  target_link_libraries(bill INTERFACE z3)
+endif()
 
 # Documentation
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,18 @@ option(BILL_TESTS "Build tests" OFF)
 # =============================================================================
 add_subdirectory(lib)
 
+# Z3
+# =============================================================================
+add_library(z3int INTERFACE)
+target_include_directories(z3int SYSTEM INTERFACE /usr/local/include)
+target_link_directories(z3int INTERFACE /usr/local/lib)
+target_link_libraries(z3int INTERFACE z3)
+
 # Library
 # =============================================================================
 add_library(bill INTERFACE)
 target_include_directories(bill INTERFACE ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(bill INTERFACE fmt)
+target_link_libraries(bill INTERFACE fmt z3int)
 
 # Documentation
 # =============================================================================

--- a/include/bill/sat/interface/common.hpp
+++ b/include/bill/sat/interface/common.hpp
@@ -137,7 +137,9 @@ enum class solvers {
 	maple,
 	bsat2,
 	bmcg,
+#if defined(BILL_HAS_Z3)
 	z3
+#endif
 #endif
 };
 

--- a/include/bill/sat/interface/common.hpp
+++ b/include/bill/sat/interface/common.hpp
@@ -137,6 +137,7 @@ enum class solvers {
 	maple,
 	bsat2,
 	bmcg,
+	z3
 #endif
 };
 

--- a/include/bill/sat/interface/z3.hpp
+++ b/include/bill/sat/interface/z3.hpp
@@ -10,6 +10,7 @@
 #include "types.hpp"
 
 #include <fmt/format.h>
+#include <limits>
 #include <vector>
 #include <z3++.h>
 
@@ -21,7 +22,8 @@ public:
 #pragma region Constructors
 	solver()
 	    : solver_(ctx_)
-	{}
+	{
+	}
 
 	~solver()
 	{}
@@ -102,13 +104,14 @@ public:
 	}
 
 	result::states solve(std::vector<lit_type> const& assumptions = {},
-	                     uint32_t conflict_limit = 0)
+	                     uint32_t conflict_limit = 0u)
 	{
 		(void) conflict_limit;
 		z3::expr_vector vec(ctx_);
 		for (auto const& lit : assumptions)
 			vec.push_back(lit.is_complemented() ? !vars_[lit.variable()] :
 			                                      vars_[lit.variable()]);
+		solver_.set("sat.max_conflicts", conflict_limit == 0u ? std::numeric_limits<uint32_t>::max() : conflict_limit);
 		switch (solver_.check(vec)) {
 		case z3::sat:
 			state_ = result::states::satisfiable;
@@ -121,6 +124,7 @@ public:
 			state_ = result::states::undefined;
 			break;
 		};
+		z3::reset_params();
 		return state_;
 	}
 #pragma endregion

--- a/include/bill/sat/interface/z3.hpp
+++ b/include/bill/sat/interface/z3.hpp
@@ -1,0 +1,142 @@
+/*-------------------------------------------------------------------------------------------------
+| This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*------------------------------------------------------------------------------------------------*/
+#pragma once
+
+#include "common.hpp"
+#include "types.hpp"
+
+#include <fmt/format.h>
+#include <vector>
+#include <z3++.h>
+
+namespace bill {
+
+#if !defined(BILL_WINDOWS_PLATFORM)
+template<>
+class solver<solvers::z3> {
+public:
+#pragma region Constructors
+	solver()
+	    : solver_(ctx_)
+	{}
+
+	~solver()
+	{}
+
+	/* disallow copying */
+	solver(solver<solvers::z3> const&) = delete;
+	solver<solvers::z3>& operator=(const solver<solvers::z3>&) = delete;
+#pragma endregion
+
+#pragma region Modifiers
+	void restart()
+	{
+		solver_.reset();
+		vars_.clear();
+		var_ctr_ = 0u;
+		cls_ctr_ = 0u;
+		state_ = result::states::undefined;
+	}
+
+	var_type add_variable()
+	{
+		vars_.push_back(ctx_.bool_const(fmt::format("x{}", var_ctr_).c_str()));
+		return var_ctr_++;
+	}
+
+	void add_variables(uint32_t num_variables = 1)
+	{
+		for (auto i = 0u; i < num_variables; ++i) {
+			add_variable();
+		}
+	}
+
+	auto add_clause(std::vector<lit_type>::const_iterator it,
+	                std::vector<lit_type>::const_iterator ie)
+	{
+		z3::expr_vector vec(ctx_);
+		while (it != ie) {
+			vec.push_back(it->is_complemented() ? !vars_[it->variable()] :
+			                                      vars_[it->variable()]);
+			++it;
+		}
+		solver_.add(mk_or(vec));
+		++cls_ctr_;
+		return result::states::dirty;
+	}
+
+	auto add_clause(std::vector<lit_type> const& clause)
+	{
+		return add_clause(std::begin(clause), std::end(clause));
+	}
+
+	auto add_clause(lit_type lit)
+	{
+		solver_.add(lit.is_complemented() ? !vars_[lit.variable()] : vars_[lit.variable()]);
+		return result::states::dirty;
+	}
+
+	result get_model() const
+	{
+		assert(state_ == result::states::satisfiable);
+		result::model_type model;
+		const auto m = solver_.get_model();
+		for (auto const& v : vars_) {
+			model.emplace_back(m.eval(v).is_true() ? lbool_type::true_ :
+			                                         lbool_type::false_);
+		}
+		return result(model);
+	}
+
+	result get_result() const
+	{}
+
+	result::states solve(std::vector<lit_type> const& assumptions = {},
+	                     uint32_t conflict_limit = 0)
+	{
+		(void) conflict_limit;
+		z3::expr_vector vec(ctx_);
+		for (auto const& lit : assumptions)
+			vec.push_back(lit.is_complemented() ? !vars_[lit.variable()] :
+			                                      vars_[lit.variable()]);
+		switch (solver_.check(vec)) {
+		case z3::sat:
+			state_ = result::states::satisfiable;
+			break;
+		case z3::unsat:
+			state_ = result::states::unsatisfiable;
+			break;
+		case z3::unknown:
+		default:
+			state_ = result::states::undefined;
+			break;
+		};
+		return state_;
+	}
+#pragma endregion
+
+#pragma region Properties
+	uint32_t num_variables() const
+	{
+		return var_ctr_;
+	}
+
+	uint32_t num_clauses() const
+	{
+		return cls_ctr_;
+	}
+#pragma endregion
+
+private:
+	z3::context ctx_;
+	z3::solver solver_;
+	result::states state_ = result::states::undefined;
+	std::vector<z3::expr> vars_;
+	uint32_t var_ctr_{};
+	uint32_t cls_ctr_{};
+};
+#endif
+
+} // namespace bill

--- a/include/bill/sat/interface/z3.hpp
+++ b/include/bill/sat/interface/z3.hpp
@@ -4,6 +4,8 @@
 *------------------------------------------------------------------------------------------------*/
 #pragma once
 
+#if defined(BILL_HAS_Z3)
+
 #include "common.hpp"
 #include "types.hpp"
 
@@ -13,7 +15,6 @@
 
 namespace bill {
 
-#if !defined(BILL_WINDOWS_PLATFORM)
 template<>
 class solver<solvers::z3> {
 public:
@@ -91,7 +92,14 @@ public:
 	}
 
 	result get_result() const
-	{}
+	{
+		assert(state_ != result::states::dirty);
+		if (state_ == result::states::satisfiable) {
+			return get_model();
+		} else {
+			return result();
+		}
+	}
 
 	result::states solve(std::vector<lit_type> const& assumptions = {},
 	                     uint32_t conflict_limit = 0)
@@ -137,6 +145,7 @@ private:
 	uint32_t var_ctr_{};
 	uint32_t cls_ctr_{};
 };
-#endif
 
 } // namespace bill
+
+#endif

--- a/include/bill/sat/solver.hpp
+++ b/include/bill/sat/solver.hpp
@@ -9,3 +9,4 @@
 #include "interface/ghack.hpp"
 #include "interface/glucose.hpp"
 #include "interface/maple.hpp"
+#include "interface/z3.hpp"

--- a/tests/sat/sat.cpp
+++ b/tests/sat/sat.cpp
@@ -14,10 +14,14 @@ using namespace bill;
 
 #if defined(BILL_WINDOWS_PLATFORM)
 #define SOLVER_TYPES solver<solvers::glucose_41>, solver<solvers::ghack>
-#else
+#elif defined(BILL_HAS_Z3)
 #define SOLVER_TYPES                                                                 \
 	solver<solvers::glucose_41>, solver<solvers::ghack>, solver<solvers::maple>, \
           solver<solvers::bsat2>, solver<solvers::bmcg>, solver<solvers::z3>
+#else
+#define SOLVER_TYPES                                                                 \
+	solver<solvers::glucose_41>, solver<solvers::ghack>, solver<solvers::maple>, \
+          solver<solvers::bsat2>, solver<solvers::bmcg>
 #endif
 
 TEMPLATE_TEST_CASE("Simple SAT", "[sat][template]", SOLVER_TYPES)

--- a/tests/sat/sat.cpp
+++ b/tests/sat/sat.cpp
@@ -17,7 +17,7 @@ using namespace bill;
 #else
 #define SOLVER_TYPES                                                                 \
 	solver<solvers::glucose_41>, solver<solvers::ghack>, solver<solvers::maple>, \
-          solver<solvers::bsat2>, solver<solvers::bmcg>
+          solver<solvers::bsat2>, solver<solvers::bmcg>, solver<solvers::z3>
 #endif
 
 TEMPLATE_TEST_CASE("Simple SAT", "[sat][template]", SOLVER_TYPES)


### PR DESCRIPTION
This PR integrates Z3 as a solver, but it needs to be enabled through CMake. It uses an installed version, include and library paths can be set as parameters.