### PR TITLE
`add_xor_clause`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ v0.1 (not yet released)
     - Ternary Boolean type (`lbool_type`)
 * Encodings:
     - Tseytin encoding (`add_tseytin_and`, `add_tseytin_or`, `add_tseytin_xor`, `add_tseytin_equals`) `#4 <https://github.com/lsils/bill/pull/4>`_
+    - XOR clauses (`add_xor_clause`)
 * Cardinality constraints:
     - At least one (`at_least_one`)
     - At most one pairwise (`at_most_one_pairwise`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,7 +16,7 @@ v0.1 (not yet released)
     - Ternary Boolean type (`lbool_type`)
 * Encodings:
     - Tseytin encoding (`add_tseytin_and`, `add_tseytin_or`, `add_tseytin_xor`, `add_tseytin_equals`) `#4 <https://github.com/lsils/bill/pull/4>`_
-    - XOR clauses (`add_xor_clause`)
+    - XOR clauses (`add_xor_clause`) `#24 <https://github.com/lsils/bill/pull/24>`_
 * Cardinality constraints:
     - At least one (`at_least_one`)
     - At most one pairwise (`at_most_one_pairwise`)

--- a/include/bill/sat/xor_clauses.hpp
+++ b/include/bill/sat/xor_clauses.hpp
@@ -1,0 +1,42 @@
+/*-------------------------------------------------------------------------------------------------
+| This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*------------------------------------------------------------------------------------------------*/
+#pragma once
+
+#include "interface/types.hpp"
+
+#include <queue>
+#include <vector>
+
+namespace bill {
+
+template<typename Solver>
+lit_type add_xor_clause(Solver& solver, std::vector<lit_type> const& clause,
+                        lit_type::polarities pol = lit_type::polarities::positive)
+{
+	std::queue<lit_type> lits;
+	bool first = pol == lit_type::polarities::negative;
+	for (const auto& l : clause) {
+		if (first) {
+			lits.push(~l);
+			first = false;
+		} else {
+			lits.push(l);
+		}
+	}
+
+	while (lits.size() > 1) {
+		auto const a = lits.front();
+		lits.pop();
+		auto const b = lits.front();
+		lits.pop();
+
+		lits.push(add_tseytin_xor(solver, a, b));
+	}
+
+	assert(lits.size() == 1u);
+	return lits.front();
+}
+
+} /* namespace bill */

--- a/tests/sat/sat.cpp
+++ b/tests/sat/sat.cpp
@@ -195,13 +195,13 @@ TEMPLATE_TEST_CASE("XOR clause", "[sat][template]", SOLVER_TYPES)
 		auto const t1 = add_xor_clause(solver, {a, b, c}, lit_type::polarities::negative);
 		solver.add_clause(t1);
 
-		/* unsatisifable solutions: a + b + c is even */
+		/* unsatisifable solutions: a + b + c is odd */
 		CHECK(solver.solve({a, ~b, ~c}) == result::states::unsatisfiable);
 		CHECK(solver.solve({~a, b, ~c}) == result::states::unsatisfiable);
 		CHECK(solver.solve({~a, ~b, c}) == result::states::unsatisfiable);
 		CHECK(solver.solve({a, b, c}) == result::states::unsatisfiable);
 
-		/* satisifable solutions: a + b + c is odd */
+		/* satisifable solutions: a + b + c is even */
 		CHECK(solver.solve({~a, ~b, ~c}) == result::states::satisfiable);
 		CHECK(solver.solve({a, b, ~c}) == result::states::satisfiable);
 		CHECK(solver.solve({a, ~b, c}) == result::states::satisfiable);

--- a/tests/sat/sat.cpp
+++ b/tests/sat/sat.cpp
@@ -7,6 +7,7 @@
 
 #include <bill/sat/solver.hpp>
 #include <bill/sat/tseytin.hpp>
+#include <bill/sat/xor_clauses.hpp>
 #include <iostream>
 #include <vector>
 
@@ -17,11 +18,11 @@ using namespace bill;
 #elif defined(BILL_HAS_Z3)
 #define SOLVER_TYPES                                                                 \
 	solver<solvers::glucose_41>, solver<solvers::ghack>, solver<solvers::maple>, \
-          solver<solvers::bsat2>, solver<solvers::bmcg>, solver<solvers::z3>
+	    solver<solvers::bsat2>, solver<solvers::bmcg>, solver<solvers::z3>
 #else
 #define SOLVER_TYPES                                                                 \
 	solver<solvers::glucose_41>, solver<solvers::ghack>, solver<solvers::maple>, \
-          solver<solvers::bsat2>, solver<solvers::bmcg>
+	    solver<solvers::bsat2>, solver<solvers::bmcg>
 #endif
 
 TEMPLATE_TEST_CASE("Simple SAT", "[sat][template]", SOLVER_TYPES)
@@ -158,4 +159,52 @@ TEMPLATE_TEST_CASE("Restart", "[sat][template]", SOLVER_TYPES)
 	CHECK(solver.solve() != result::states::unsatisfiable);
 	CHECK(solver.num_variables() == 0u);
 	CHECK(solver.num_clauses() == 0u);
+}
+
+TEMPLATE_TEST_CASE("XOR clause", "[sat][template]", SOLVER_TYPES)
+{
+	TestType solver;
+	{
+		auto const a = lit_type(solver.add_variable(), lit_type::polarities::positive);
+		auto const b = lit_type(solver.add_variable(), lit_type::polarities::positive);
+		auto const c = lit_type(solver.add_variable(), lit_type::polarities::positive);
+
+		auto const t0 = add_xor_clause(solver, {a, b, c});
+		solver.add_clause(t0);
+
+		/* satisifable solutions: a + b + c is odd */
+		CHECK(solver.solve({a, ~b, ~c}) == result::states::satisfiable);
+		CHECK(solver.solve({~a, b, ~c}) == result::states::satisfiable);
+		CHECK(solver.solve({~a, ~b, c}) == result::states::satisfiable);
+		CHECK(solver.solve({a, b, c}) == result::states::satisfiable);
+
+		/* unsatisifable solutions: a + b + c is even */
+		CHECK(solver.solve({~a, ~b, ~c}) == result::states::unsatisfiable);
+		CHECK(solver.solve({a, b, ~c}) == result::states::unsatisfiable);
+		CHECK(solver.solve({a, ~b, c}) == result::states::unsatisfiable);
+		CHECK(solver.solve({~a, b, c}) == result::states::unsatisfiable);
+	}
+
+	solver.restart();
+
+	{
+		auto const a = lit_type(solver.add_variable(), lit_type::polarities::positive);
+		auto const b = lit_type(solver.add_variable(), lit_type::polarities::positive);
+		auto const c = lit_type(solver.add_variable(), lit_type::polarities::positive);
+
+		auto const t1 = add_xor_clause(solver, {a, b, c}, lit_type::polarities::negative);
+		solver.add_clause(t1);
+
+		/* unsatisifable solutions: a + b + c is even */
+		CHECK(solver.solve({a, ~b, ~c}) == result::states::unsatisfiable);
+		CHECK(solver.solve({~a, b, ~c}) == result::states::unsatisfiable);
+		CHECK(solver.solve({~a, ~b, c}) == result::states::unsatisfiable);
+		CHECK(solver.solve({a, b, c}) == result::states::unsatisfiable);
+
+		/* satisifable solutions: a + b + c is odd */
+		CHECK(solver.solve({~a, ~b, ~c}) == result::states::satisfiable);
+		CHECK(solver.solve({a, b, ~c}) == result::states::satisfiable);
+		CHECK(solver.solve({a, ~b, c}) == result::states::satisfiable);
+		CHECK(solver.solve({~a, b, c}) == result::states::satisfiable);
+	}
 }


### PR DESCRIPTION
This PR allows adding XOR clauses of the form `x0 + x1 + ... + xn = c` to the solver.

The PR requires the changes of PR #23 to pass its tests.