### PR TITLE
Enable bsat2 on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ add_subdirectory(lib)
 add_library(bill INTERFACE)
 target_include_directories(bill INTERFACE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(bill INTERFACE fmt)
+if(WIN32)
+  target_compile_definitions(bill INTERFACE NOMINMAX)
+endif()
 
 # Z3 (optional)
 # =============================================================================

--- a/include/bill/sat/interface/abc_bsat2.hpp
+++ b/include/bill/sat/interface/abc_bsat2.hpp
@@ -13,7 +13,6 @@
 
 namespace bill {
 
-#if !defined(BILL_WINDOWS_PLATFORM)
 template<>
 class solver<solvers::bsat2> {
 	using solver_type = pabc::sat_solver;
@@ -162,6 +161,5 @@ private:
 	/*! \brief Temporary storage for one clause */
 	pabc::lit literals[2048];
 };
-#endif
 
 } // namespace bill

--- a/include/bill/sat/interface/common.hpp
+++ b/include/bill/sat/interface/common.hpp
@@ -12,6 +12,10 @@
     disable : 4018 4127 4189 4200 4242 4244 4245 4305 4365 4388 4389 4456 4457 4459 4514 4552 4571 4583 4619 4623 4625 4626 4706 4710 4711 4774 4820 4820 4996 5026 5027 5039)
 #include "../solver/ghack.hpp"
 #include "../solver/glucose.hpp"
+#define ABC_USE_NAMESPACE pabc
+#define ABC_NAMESPACE pabc
+#define ABC_USE_NO_READLINE
+#include "../solver/abc.hpp"
 #pragma warning(pop)
 #else
 #pragma GCC diagnostic push
@@ -27,7 +31,6 @@
 #include "../solver/ghack.hpp"
 #include "../solver/glucose.hpp"
 #include "../solver/maple.hpp"
-#if !defined(BILL_WINDOWS_PLATFORM)
 #ifndef LIN64
 #define LIN64
 #endif
@@ -35,7 +38,6 @@
 #define ABC_NAMESPACE pabc
 #define ABC_USE_NO_READLINE
 #include "../solver/abc.hpp"
-#endif
 #pragma GCC diagnostic pop
 #endif
 
@@ -135,9 +137,9 @@ private:
 enum class solvers {
 	glucose_41,
 	ghack,
+	bsat2,
 #if !defined(BILL_WINDOWS_PLATFORM)
 	maple,
-	bsat2,
 	bmcg,
 #endif
 #if defined(BILL_HAS_Z3)

--- a/test/sat/sat.cpp
+++ b/test/sat/sat.cpp
@@ -14,9 +14,9 @@
 using namespace bill;
 
 #if defined(BILL_WINDOWS_PLATFORM) && defined(BILL_HAS_Z3)
-#define SOLVER_TYPES solver<solvers::glucose_41>, solver<solvers::ghack>, solver<solvers::z3>
+#define SOLVER_TYPES solver<solvers::glucose_41>, solver<solvers::ghack>, solver<solvers::bsat2>, solver<solvers::z3>
 #elif defined(BILL_WINDOWS_PLATFORM) && !defined(BILL_HAS_Z3)
-#define SOLVER_TYPES solver<solvers::glucose_41>, solver<solvers::ghack>
+#define SOLVER_TYPES solver<solvers::glucose_41>, solver<solvers::ghack>, solver<solvers::bsat2>
 #elif !defined(BILL_WINDOWS_PLATFORM) && defined(BILL_HAS_Z3)
 #define SOLVER_TYPES                                                                 \
 	solver<solvers::glucose_41>, solver<solvers::ghack>, solver<solvers::maple>, \


### PR DESCRIPTION
ABC bsat2 runs on Windows. This enables its use on Windows platforms. @lee30sonia 