### PR TITLE
Manually count variables and clauses in bsat2

### DIFF
--- a/include/bill/sat/interface/abc_bsat2.hpp
+++ b/include/bill/sat/interface/abc_bsat2.hpp
@@ -20,7 +20,7 @@ class solver<solvers::bsat2> {
 
 public:
 #pragma region Constructors
-	solver() : var_ctr_( 1, 0u ), cls_ctr_( 1, 0u )
+	solver() : var_ctr_( 1, 0u ), cls_ctr_( 1, 0 )
 	{
 		solver_ = pabc::sat_solver_new();
 	}
@@ -45,7 +45,7 @@ public:
 		var_ctr_.clear();
 		var_ctr_.emplace_back( 0u );
 		cls_ctr_.clear();
-		cls_ctr_.emplace_back( 0u );
+		cls_ctr_.emplace_back( 0 );
 	}
 
 	var_type add_variable()
@@ -84,6 +84,7 @@ public:
 
 	auto add_clause(lit_type lit)
 	{
+		--cls_ctr_.back(); /* do not count unit clauses */
 		return add_clause(std::vector<lit_type>{lit});
 	}
 
@@ -210,7 +211,7 @@ private:
 	std::default_random_engine random;
 	bool randomize = false;
 	std::vector<uint32_t> var_ctr_;
-	std::vector<uint32_t> cls_ctr_;
+	std::vector<int> cls_ctr_;
 };
 
 } // namespace bill

--- a/include/bill/sat/interface/abc_bsat2.hpp
+++ b/include/bill/sat/interface/abc_bsat2.hpp
@@ -8,9 +8,9 @@
 #include "types.hpp"
 
 #include <memory>
+#include <random>
 #include <variant>
 #include <vector>
-#include <random>
 
 namespace bill {
 
@@ -20,7 +20,9 @@ class solver<solvers::bsat2> {
 
 public:
 #pragma region Constructors
-	solver() : variable_counter( 1, 0u ), clause_counter( 1, 0 )
+	solver()
+	    : variable_counter(1, 0u)
+	    , clause_counter(1, 0)
 	{
 		solver_ = pabc::sat_solver_new();
 	}
@@ -43,9 +45,9 @@ public:
 		state_ = result::states::undefined;
 		randomize = false;
 		variable_counter.clear();
-		variable_counter.emplace_back( 0u );
+		variable_counter.emplace_back(0u);
 		clause_counter.clear();
-		clause_counter.emplace_back( 0 );
+		clause_counter.emplace_back(0);
 	}
 
 	var_type add_variable()
@@ -120,17 +122,16 @@ public:
 		if (num_variables() == 0u)
 			return result::states::undefined;
 
-		if ( randomize )
-		{
+		if (randomize) {
 			std::vector<uint32_t> vars;
-			for ( auto i = 0u; i < num_variables(); ++i )
-			{
-				if ( random() % 2 )
-				{
-					vars.push_back( i );
+			for (auto i = 0u; i < num_variables(); ++i) {
+				if (random() % 2) {
+					vars.push_back(i);
 				}
 			}
-			pabc::sat_solver_set_polarity( solver_, (int*)(const_cast<uint32_t*>(vars.data())), vars.size() );
+			pabc::sat_solver_set_polarity(solver_,
+			                              (int*) (const_cast<uint32_t*>(vars.data())),
+			                              vars.size());
 		}
 
 		int result;
@@ -179,23 +180,23 @@ public:
 	void push()
 	{
 		pabc::sat_solver_bookmark(solver_);
-		variable_counter.emplace_back( variable_counter.back() );
-		clause_counter.emplace_back( clause_counter.back() );
+		variable_counter.emplace_back(variable_counter.back());
+		clause_counter.emplace_back(clause_counter.back());
 	}
 
-	void pop( uint32_t num_levels = 1u )
+	void pop(uint32_t num_levels = 1u)
 	{
-		assert( num_levels == 1u && "bsat does not support multiple step pop" );
+		assert(num_levels == 1u && "bsat does not support multiple step pop");
 		pabc::sat_solver_rollback(solver_);
-		variable_counter.resize( variable_counter.size() - num_levels );
-		clause_counter.resize( clause_counter.size() - num_levels );
+		variable_counter.resize(variable_counter.size() - num_levels);
+		clause_counter.resize(clause_counter.size() - num_levels);
 	}
 
-	void set_random_phase( uint32_t seed = 0u )
+	void set_random_phase(uint32_t seed = 0u)
 	{
 		randomize = true;
 		pabc::sat_solver_set_random(solver_, 1);
-		random.seed( seed );
+		random.seed(seed);
 	}
 
 private:

--- a/include/bill/sat/interface/abc_bsat2.hpp
+++ b/include/bill/sat/interface/abc_bsat2.hpp
@@ -20,7 +20,7 @@ class solver<solvers::bsat2> {
 
 public:
 #pragma region Constructors
-	solver()
+	solver() : var_ctr_( 1, 0u ), cls_ctr_( 1, 0u )
 	{
 		solver_ = pabc::sat_solver_new();
 	}
@@ -42,15 +42,21 @@ public:
 		pabc::sat_solver_restart(solver_);
 		state_ = result::states::undefined;
 		randomize = false;
+		var_ctr_.clear();
+		var_ctr_.emplace_back( 0u );
+		cls_ctr_.clear();
+		cls_ctr_.emplace_back( 0u );
 	}
 
 	var_type add_variable()
 	{
+		++var_ctr_.back();
 		return pabc::sat_solver_addvar(solver_);
 	}
 
 	void add_variables(uint32_t num_variables = 1)
 	{
+		var_ctr_.back() += num_variables;
 		for (auto i = 0u; i < num_variables; ++i) {
 			pabc::sat_solver_addvar(solver_);
 		}
@@ -59,6 +65,7 @@ public:
 	auto add_clause(std::vector<lit_type>::const_iterator it,
 	                std::vector<lit_type>::const_iterator ie)
 	{
+		++cls_ctr_.back();
 		auto counter = 0u;
 		while (it != ie) {
 			literals[counter++] = pabc::Abc_Var2Lit(it->variable(),
@@ -157,24 +164,30 @@ public:
 #pragma region Properties
 	uint32_t num_variables() const
 	{
-		return pabc::sat_solver_nvars(solver_);
+		return var_ctr_.back();
+		//return pabc::sat_solver_nvars(solver_);
 	}
 
 	uint32_t num_clauses() const
 	{
-		return pabc::sat_solver_nclauses(solver_);
+		return cls_ctr_.back();
+		//return pabc::sat_solver_nclauses(solver_);
 	}
 #pragma endregion
 
 	void push()
 	{
 		pabc::sat_solver_bookmark(solver_);
+		var_ctr_.emplace_back( var_ctr_.back() );
+		cls_ctr_.emplace_back( cls_ctr_.back() );
 	}
 
 	void pop( uint32_t n = 1u )
 	{
 		assert( n == 1u && "bsat does not support multiple step pop" ); (void)n;
 	    pabc::sat_solver_rollback(solver_);
+	    var_ctr_.resize( var_ctr_.size() - 1 );
+		cls_ctr_.resize( cls_ctr_.size() - 1 );
 	}
 
 	void set_random_phase( uint32_t seed = 0u )
@@ -196,6 +209,8 @@ private:
 
 	std::default_random_engine random;
 	bool randomize = false;
+	std::vector<uint32_t> var_ctr_;
+	std::vector<uint32_t> cls_ctr_;
 };
 
 } // namespace bill

--- a/include/bill/sat/interface/z3.hpp
+++ b/include/bill/sat/interface/z3.hpp
@@ -21,9 +21,10 @@ class solver<solvers::z3> {
 public:
 #pragma region Constructors
 	solver()
-	    : solver_(ctx_), variable_counter_( 1, 0u ), clause_counter_( 1, 0u )
-	{
-	}
+	    : solver_(ctx_)
+	    , variable_counter_(1, 0u)
+	    , clause_counter_(1, 0u)
+	{}
 
 	~solver()
 	{}
@@ -39,9 +40,9 @@ public:
 		solver_.reset();
 		vars_.clear();
 		variable_counter_.clear();
-		variable_counter_.emplace_back( 0u );
+		variable_counter_.emplace_back(0u);
 		clause_counter_.clear();
-		clause_counter_.emplace_back( 0u );
+		clause_counter_.emplace_back(0u);
 		state_ = result::states::undefined;
 	}
 
@@ -112,7 +113,9 @@ public:
 		for (auto const& lit : assumptions)
 			vec.push_back(lit.is_complemented() ? !vars_[lit.variable()] :
 			                                      vars_[lit.variable()]);
-		solver_.set("sat.max_conflicts", conflict_limit == 0u ? std::numeric_limits<uint32_t>::max() : conflict_limit);
+		solver_.set("sat.max_conflicts", conflict_limit == 0u ?
+		                                     std::numeric_limits<uint32_t>::max() :
+		                                     conflict_limit);
 		switch (solver_.check(vec)) {
 		case z3::sat:
 			state_ = result::states::satisfiable;
@@ -145,23 +148,22 @@ public:
 	void push()
 	{
 		solver_.push();
-		variable_counter_.emplace_back( variable_counter_.back() );
-		clause_counter_.emplace_back( clause_counter_.back() );
+		variable_counter_.emplace_back(variable_counter_.back());
+		clause_counter_.emplace_back(clause_counter_.back());
 	}
 
-	void pop( uint32_t num_levels = 1u )
+	void pop(uint32_t num_levels = 1u)
 	{
-		assert( num_levels < variable_counter_.size() );
-		solver_.pop( num_levels );
-		variable_counter_.resize( variable_counter_.size() - num_levels );
-		clause_counter_.resize( clause_counter_.size() - num_levels );
-		if ( vars_.size() > variable_counter_.back() )
-		{
-			vars_.erase( vars_.begin() + variable_counter_.back(), vars_.end() );
+		assert(num_levels < variable_counter_.size());
+		solver_.pop(num_levels);
+		variable_counter_.resize(variable_counter_.size() - num_levels);
+		clause_counter_.resize(clause_counter_.size() - num_levels);
+		if (vars_.size() > variable_counter_.back()) {
+			vars_.erase(vars_.begin() + variable_counter_.back(), vars_.end());
 		}
 	}
 
-	void set_random_phase( uint32_t seed = 0u )
+	void set_random_phase(uint32_t seed = 0u)
 	{
 		solver_.set("sat.random_seed", seed);
 		solver_.set("phase_selection", 5u);

--- a/include/bill/sat/interface/z3.hpp
+++ b/include/bill/sat/interface/z3.hpp
@@ -21,7 +21,7 @@ class solver<solvers::z3> {
 public:
 #pragma region Constructors
 	solver()
-	    : solver_(ctx_), var_ctr_( 1, 0u ), cls_ctr_( 1, 0u )
+	    : solver_(ctx_), variable_counter_( 1, 0u ), clause_counter_( 1, 0u )
 	{
 	}
 
@@ -38,17 +38,17 @@ public:
 	{
 		solver_.reset();
 		vars_.clear();
-		var_ctr_.clear();
-		var_ctr_.emplace_back( 0u );
-		cls_ctr_.clear();
-		cls_ctr_.emplace_back( 0u );
+		variable_counter_.clear();
+		variable_counter_.emplace_back( 0u );
+		clause_counter_.clear();
+		clause_counter_.emplace_back( 0u );
 		state_ = result::states::undefined;
 	}
 
 	var_type add_variable()
 	{
-		vars_.push_back(ctx_.bool_const(fmt::format("x{}", var_ctr_.back()).c_str()));
-		return var_ctr_.back()++;
+		vars_.push_back(ctx_.bool_const(fmt::format("x{}", variable_counter_.back()).c_str()));
+		return variable_counter_.back()++;
 	}
 
 	void add_variables(uint32_t num_variables = 1)
@@ -68,7 +68,7 @@ public:
 			++it;
 		}
 		solver_.add(mk_or(vec));
-		++cls_ctr_.back();
+		++clause_counter_.back();
 		return result::states::dirty;
 	}
 
@@ -133,31 +133,31 @@ public:
 #pragma region Properties
 	uint32_t num_variables() const
 	{
-		return var_ctr_.back();
+		return variable_counter_.back();
 	}
 
 	uint32_t num_clauses() const
 	{
-		return cls_ctr_.back();
+		return clause_counter_.back();
 	}
 #pragma endregion
 
 	void push()
 	{
 		solver_.push();
-		var_ctr_.emplace_back( var_ctr_.back() );
-		cls_ctr_.emplace_back( cls_ctr_.back() );
+		variable_counter_.emplace_back( variable_counter_.back() );
+		clause_counter_.emplace_back( clause_counter_.back() );
 	}
 
-	void pop( uint32_t n = 1u )
+	void pop( uint32_t num_levels = 1u )
 	{
-		assert( n < var_ctr_.size() );
-		solver_.pop( n );
-		var_ctr_.resize( var_ctr_.size() - n );
-		cls_ctr_.resize( cls_ctr_.size() - n );
-		if ( vars_.size() > var_ctr_.back() )
+		assert( num_levels < variable_counter_.size() );
+		solver_.pop( num_levels );
+		variable_counter_.resize( variable_counter_.size() - num_levels );
+		clause_counter_.resize( clause_counter_.size() - num_levels );
+		if ( vars_.size() > variable_counter_.back() )
 		{
-			vars_.erase( vars_.begin() + var_ctr_.back(), vars_.end() );
+			vars_.erase( vars_.begin() + variable_counter_.back(), vars_.end() );
 		}
 	}
 
@@ -168,12 +168,23 @@ public:
 	}
 
 private:
+	/*! \brief Backend solver context object */
 	z3::context ctx_;
+
+	/*! \brief Backend solver */
 	z3::solver solver_;
+
+	/*! \brief Current state of the solver */
 	result::states state_ = result::states::undefined;
+
+	/*! \brief Variables */
 	std::vector<z3::expr> vars_;
-	std::vector<uint32_t> var_ctr_;
-	std::vector<uint32_t> cls_ctr_;
+
+	/*! \brief Stacked counter for number of variables */
+	std::vector<uint32_t> variable_counter_;
+
+	/*! \brief Stacked counter for number of clauses */
+	std::vector<uint32_t> clause_counter_;
 };
 
 } // namespace bill

--- a/test/sat/sat.cpp
+++ b/test/sat/sat.cpp
@@ -242,12 +242,14 @@ TEMPLATE_TEST_CASE("Push/pop", "[sat][template]", STACKABLE_SOLVER_TYPES)
 	const auto b = bill::lit_type{solver.add_variable()};
 	const auto f = bill::lit_type{solver.add_variable()};
 
-	solver.add_clause({~zero});
+	solver.add_clause(~zero);
 	solver.add_clause({~a, b, f});
 	solver.add_clause({a, ~b, f});
 	solver.add_clause({a, b, ~f});
 	solver.add_clause({~a, ~b, ~f});
 
+	CHECK(solver.num_variables() == 4u);
+	CHECK(solver.num_clauses() == 4u);
 	CHECK(solver.solve({f}) == bill::result::states::satisfiable);
 	
 	solver.push();
@@ -258,5 +260,7 @@ TEMPLATE_TEST_CASE("Push/pop", "[sat][template]", STACKABLE_SOLVER_TYPES)
 	CHECK(solver.solve({f}) == bill::result::states::unsatisfiable);
 
 	solver.pop();
+	CHECK(solver.num_variables() == 4u);
+	CHECK(solver.num_clauses() == 4u);
 	CHECK(solver.solve({f}) == bill::result::states::satisfiable);
 }


### PR DESCRIPTION
`bsat2` doesn't really handle the variable and clause count very well, at least when bookmark/rollback is used. So I port the manual counting code from the wrapper of `z3` here.