### PR TITLE
Conflicting macros between GHack and CUDD

### DIFF
--- a/include/bill/sat/solver/ghack.hpp
+++ b/include/bill/sat/solver/ghack.hpp
@@ -2793,13 +2793,12 @@ inline void Solver::write_char (unsigned char ch) {
   b[e++] = ch; }
   //if (putc_unlocked ((int)
 #define write_char b[e++] =
-#define DD fwrite(b, 1, e, certifiedOutput), e = 0;
   //= EOF) exit(1); }
 
 inline void Solver::write_lit (int n) {
   for (; n > 127; n >>= 7)
     write_char (128 | (n & 127));
-   write_char (n); if (e > 1048576) DD }
+   write_char (n); if (e > 1048576) fwrite(b, 1, e, certifiedOutput), e = 0; }
 
 inline bool Solver::addClause_(vec<Lit>& ps)
 {
@@ -3933,7 +3932,7 @@ printf("c ==================================[ Search Statistics (every %6d confl
         if (vbyte) {
           write_char('a');
           write_lit(0);
-          DD
+          fwrite(b, 1, e, certifiedOutput), e = 0;
         }
         else {
   	  fprintf(certifiedOutput, "0\n");


### PR DESCRIPTION
This PR inlines the macro definition `DD` in the solver backend GHack to avoid a conflict with the macros exported by CUDD.