### PR TITLE
Undefine all macros defined in the solvers

### DIFF
--- a/include/bill/sat/solver/abc.hpp
+++ b/include/bill/sat/solver/abc.hpp
@@ -5918,3 +5918,10 @@ inline void glucose_print_stats(Gluco::SimpSolver& s, abctime clk)
 ////////////////////////////////////////////////////////////////////////
 
 ABC_NAMESPACE_IMPL_END
+
+#undef SAT_USE_ANALYZE_FINAL
+#undef L_IND
+#undef L_ind
+#undef L_LIT
+#undef L_lit
+#undef USE_SIMP_SOLVER

--- a/include/bill/sat/solver/ghack.hpp
+++ b/include/bill/sat/solver/ghack.hpp
@@ -5073,7 +5073,16 @@ inline void SimpSolver::garbageCollect()
 }
 
 #undef write_char
-
-inline void function()
-{
-}
+#undef var_Undef
+#undef DYNAMICNBLEVEL
+#undef CONSTANTREMOVECLAUSE
+#undef UPDATEVARACTIVITY
+#undef RATIOREMOVECLAUSES
+#undef LOWER_BOUND_FOR_BLOCKING_RESTART
+#undef M
+#undef Q
+#undef P
+#undef B
+#undef S
+#undef EE
+#undef X

--- a/include/bill/sat/solver/glucose.hpp
+++ b/include/bill/sat/solver/glucose.hpp
@@ -6384,3 +6384,15 @@ inline void SimpSolver::garbageCollect()
     to.moveTo(ca);
 }
 } // using namespace Glucose
+
+#undef BITS_LBD
+#ifdef INCREMENTAL
+  #undef BITS_SIZEWITHOUTSEL
+  #undef INCREMENTAL
+#endif
+#undef BITS_REALSIZE
+#undef DYNAMICNBLEVEL
+#undef CONSTANTREMOVECLAUSE
+#undef RATIOREMOVECLAUSES
+#undef LOWER_BOUND_FOR_BLOCKING_RESTART
+#undef coreStatsSize

--- a/include/bill/sat/solver/maple.hpp
+++ b/include/bill/sat/solver/maple.hpp
@@ -5832,3 +5832,11 @@ inline void SimpSolver::garbageCollect()
     to.moveTo(ca);
 }
 }
+
+#undef ANTI_EXPLORATION
+#undef BIN_DRUP
+#undef INT_QUEUE_AVG
+#undef LOOSE_PROP_STAT
+#undef LOCAL
+#undef TIER2
+#undef COR


### PR DESCRIPTION
Macros in the solvers can interfere with projects that use the library.

This PR clear the defined macros at the end of each solver header