### PR TITLE
Assertions for the literals buffer array in bsat2

### DIFF
--- a/include/bill/sat/interface/abc_bsat2.hpp
+++ b/include/bill/sat/interface/abc_bsat2.hpp
@@ -139,7 +139,7 @@ public:
 
 		int result;
 		if (assumptions.size() > 0u) {
-			assert(ie-it <= BUFFER_SIZE && "assumption size exceeds limit. Please increase BUFFER_SIZE in bill/sat/interface/abc_bsat2.hpp");
+			assert(assumptions.size() <= BUFFER_SIZE && "assumption size exceeds limit. Please increase BUFFER_SIZE in bill/sat/interface/abc_bsat2.hpp");
 			/* solve with assumptions */
 			uint32_t counter = 0u;
 			auto it = assumptions.begin();

--- a/include/bill/sat/interface/abc_bsat2.hpp
+++ b/include/bill/sat/interface/abc_bsat2.hpp
@@ -14,6 +14,8 @@
 
 namespace bill {
 
+#define BUFFER_SIZE 2048
+
 template<>
 class solver<solvers::bsat2> {
 	using solver_type = pabc::sat_solver;
@@ -67,6 +69,7 @@ public:
 	auto add_clause(std::vector<lit_type>::const_iterator it,
 	                std::vector<lit_type>::const_iterator ie)
 	{
+		assert(ie-it <= BUFFER_SIZE && "clause size exceeds limit. Please increase BUFFER_SIZE in bill/sat/interface/abc_bsat2.hpp");
 		++clause_counter.back();
 		auto counter = 0u;
 		while (it != ie) {
@@ -136,6 +139,7 @@ public:
 
 		int result;
 		if (assumptions.size() > 0u) {
+			assert(ie-it <= BUFFER_SIZE && "assumption size exceeds limit. Please increase BUFFER_SIZE in bill/sat/interface/abc_bsat2.hpp");
 			/* solve with assumptions */
 			uint32_t counter = 0u;
 			auto it = assumptions.begin();
@@ -207,7 +211,7 @@ private:
 	result::states state_ = result::states::undefined;
 
 	/*! \brief Temporary storage for one clause */
-	pabc::lit literals[2048];
+	pabc::lit literals[BUFFER_SIZE];
 
 	/*! \brief Whether to randomize initial variable values */
 	bool randomize = false;

--- a/include/bill/sat/interface/abc_bsat2.hpp
+++ b/include/bill/sat/interface/abc_bsat2.hpp
@@ -14,11 +14,10 @@
 
 namespace bill {
 
-#define BUFFER_SIZE 2048
-
 template<>
 class solver<solvers::bsat2> {
 	using solver_type = pabc::sat_solver;
+	static constexpr uint32_t BUFFER_SIZE = 2048;
 
 public:
 #pragma region Constructors


### PR DESCRIPTION
Adds assertions to avoid memory access error without warning.