### PR TITLE
removed '#include <fpu_control.h>' since it's not used

### DIFF
--- a/include/bill/sat/solver/ghack.hpp
+++ b/include/bill/sat/solver/ghack.hpp
@@ -1472,10 +1472,6 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Ghack_System_h
 #define Ghack_System_h
 
-#if defined(__linux__)
-#include <fpu_control.h>
-#endif
-
 
 
 //-------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR should improve compatibility with Alpine Linux, which is used for Docker images a lot. On my machine, removing these lines did not cause any test cases to fail. Let's see whether CI confirms this observation.