### PR TITLE
Fix multiple inclusion error

### DIFF
--- a/include/bill/bill.hpp
+++ b/include/bill/bill.hpp
@@ -14,7 +14,9 @@
 #include <bill/sat/solver.hpp>
 #include <bill/sat/solver/glucose.hpp>
 #include <bill/sat/solver/abc.hpp>
+#if !defined(BILL_WINDOWS_PLATFORM)
 #include <bill/sat/solver/maple.hpp>
+#endif
 #include <bill/sat/solver/ghack.hpp>
 #include <bill/sat/incremental_totalizer_cardinality.hpp>
 #include <bill/sat/xor_clauses.hpp>

--- a/include/bill/sat/solver/ghack.hpp
+++ b/include/bill/sat/solver/ghack.hpp
@@ -17,6 +17,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
+#pragma once
+
 #ifndef Ghack_IntTypes_h
 #define Ghack_IntTypes_h
 

--- a/include/bill/sat/solver/maple.hpp
+++ b/include/bill/sat/solver/maple.hpp
@@ -18,7 +18,6 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 **************************************************************************************************/
 
 #pragma once
-#if !defined(BILL_WINDOWS_PLATFORM)
 
 #ifndef Minisat_IntTypes_h
 #define Minisat_IntTypes_h
@@ -5843,4 +5842,3 @@ inline void SimpSolver::garbageCollect()
 #undef LOCAL
 #undef TIER2
 #undef COR
-#endif

--- a/include/bill/sat/solver/maple.hpp
+++ b/include/bill/sat/solver/maple.hpp
@@ -17,6 +17,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
+#pragma once
+
 #ifndef Minisat_IntTypes_h
 #define Minisat_IntTypes_h
 

--- a/include/bill/sat/solver/maple.hpp
+++ b/include/bill/sat/solver/maple.hpp
@@ -18,6 +18,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 **************************************************************************************************/
 
 #pragma once
+#if !defined(BILL_WINDOWS_PLATFORM)
 
 #ifndef Minisat_IntTypes_h
 #define Minisat_IntTypes_h
@@ -5842,3 +5843,4 @@ inline void SimpSolver::garbageCollect()
 #undef LOCAL
 #undef TIER2
 #undef COR
+#endif


### PR DESCRIPTION
There are missing `#pragma once` in some files, creating multiple inclusion error when including the library in other projects with `bill/bill.hpp`.