### PR TITLE
Ambiguity of signal in include/bill/sat/solver/maple.hpp when using namespace mockturtle

### DIFF
--- a/include/bill/sat/solver/maple.hpp
+++ b/include/bill/sat/solver/maple.hpp
@@ -2546,7 +2546,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 #include <math.h>
 #include <algorithm>
-#include <signal.h>
+#include <csignal>
 // #include <unistd.h>
 
 
@@ -4577,7 +4577,7 @@ static void SIGALRM_switch(int signum) { switch_mode = true; }
 // NOTE: assumptions passed in member-variable 'assumptions'.
 inline lbool Solver::solve_()
 {
-    signal(SIGALRM, SIGALRM_switch);
+    ::signal(SIGALRM, SIGALRM_switch);
     alarm(2500);
 
     model.clear();


### PR DESCRIPTION
See https://github.com/lsils/mockturtle/pull/448

Besides, I don't see any reason to use `<math.h>` instead of `<cmath>`.