### PR TITLE
Fixed Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
     name: Visual Studio
 
     steps:


### PR DESCRIPTION
Specified the Windows version to be `windows-2019` instead of `windows-latest` as the pipeline seems to be built for said release.